### PR TITLE
Addition of SonarQube properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+# Required metadata
+sonar.projectKey=screenforce:screening-admin-service
+sonar.projectName=Screenforce Screening Admin Service
+sonar.projectVersion=2.1
+
+# Comma-separated paths to directories with sources
+sonar.sources = src/main/java
+sonar.java.binaries = target/classes
+
+# Encoding of the source files
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
For code analysis in Jenkins
Changes project name from Caliber to Screenforce
tested in 1808 SonarQube under Project Name:
"Screenforce Screening Admin Service"